### PR TITLE
Encode chunk path to allow servers handling square brackets properly

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -70,7 +70,7 @@ self.__next_require__ =
 ;(self as any).__next_chunk_load__ = (chunk: string) => {
   if (!chunk) return Promise.resolve()
   const [chunkId, chunkFileName] = chunk.split(':')
-  chunkFilenameMap[chunkId] = `static/chunks/${chunkFileName}.js`
+  chunkFilenameMap[chunkId] = encodeURI(`static/chunks/${chunkFileName}.js`)
 
   // @ts-ignore
   // eslint-disable-next-line no-undef


### PR DESCRIPTION
### What?
Encode chunk path to allow servers handling square brackets properly

### Why?
When `appDir` is enabled in the app, bundles for dynamic routes i.e. `posts/[postIdOrSlug]` are attempted to be loaded by webpack without encoded square brackets (`[]`).

This causes `400` errors when combined by custom servers like play (https://github.com/playframework/playframework/issues/8113, [2](https://stackoverflow.com/questions/40568/are-square-brackets-permitted-in-urls)).

### How?
use `encodeUrl` before adding the chunk path to  `chunkFilenameMap`. When `__webpack_chunk_load__` is executed the encoded URL is used which allows the server to handle the request properly.

Related #48199
